### PR TITLE
Sends user confirmation email

### DIFF
--- a/src/lib/manager.js
+++ b/src/lib/manager.js
@@ -33,5 +33,24 @@ export async function getFormDefinition(formId, formStatus, versionNumber) {
 }
 
 /**
- * @import { FormDefinition } from '@defra/forms-model'
+ * Gets the form metadata from the Forms Manager API
+ * @param {string} formId
+ * @returns {Promise<FormMetadata>}
+ */
+export async function getFormMetadata(formId) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!managerUrl) {
+    //  TS / eslint conflict
+    throw new Error('Missing MANAGER_URL')
+  }
+
+  const formUrl = new URL(`/forms/${formId}`, managerUrl)
+
+  const { body } = await getJson(formUrl)
+
+  return body
+}
+
+/**
+ * @import { FormDefinition, FormMetadata } from '@defra/forms-model'
  */

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -1,5 +1,5 @@
 import { handleFormSubmissionEvents } from '~/src/service/events.js'
-import { sendNotifyEmail } from '~/src/service/notify.js'
+import { sendNotifyEmails } from '~/src/service/notify.js'
 
 /**
  * @param {Message[]} messages
@@ -7,7 +7,7 @@ import { sendNotifyEmail } from '~/src/service/notify.js'
  */
 export async function handleEvent(messages) {
   const service = {
-    handleFormSubmission: sendNotifyEmail
+    handleFormSubmission: sendNotifyEmails
   }
   return handleFormSubmissionEvents(messages, service)
 }

--- a/src/service/mappers/user-confirmation.js
+++ b/src/service/mappers/user-confirmation.js
@@ -1,0 +1,45 @@
+import { escapeMarkdown } from '@defra/forms-engine-plugin/engine/components/helpers/index.js'
+
+import { format as dateFormat } from '~/src/helpers/date.js'
+
+/**
+ * @param {string} formName
+ * @param {Date} submissionDate
+ * @param {FormMetadata} metadata
+ */
+export function getUserConfirmationEmailBody(
+  formName,
+  submissionDate,
+  metadata
+) {
+  const formattedSubmissionDate = `${dateFormat(submissionDate, 'h:mmaaa')} on ${dateFormat(submissionDate, 'eeee d MMMM yyyy')}`
+
+  const { submissionGuidance, organisation, contact } = metadata
+
+  const phoneDetails = contact?.phone ? `${contact.phone}\n\n` : ''
+  const emailDetails = contact?.email
+    ? `${contact.email.address} ${contact.email.responseTime}\n\n`
+    : ''
+  const onlineDetails = contact?.online
+    ? `${contact.online.url} ${contact.online.text}\n\n`
+    : ''
+  const contactDetails = `${phoneDetails}${emailDetails}${onlineDetails}`
+
+  return `
+# We have your form
+We received your form submission for &ldquo;${formName}&rsquo; on ${formattedSubmissionDate}.
+
+## What happens next
+${submissionGuidance}
+
+## Get help
+${contactDetails}
+Do not reply to this emall. We do not monitor reples to this email address.
+
+From ${escapeMarkdown(organisation)}
+`
+}
+
+/**
+ * @import { FormMetadata } from '@defra/forms-model'
+ */

--- a/src/service/notify.js
+++ b/src/service/notify.js
@@ -1,4 +1,5 @@
 import { escapeMarkdown } from '@defra/forms-engine-plugin/engine/components/helpers/index.js'
+import { getFormMetadata } from '@defra/forms-engine-plugin/services/formsService.js'
 import { getErrorMessage } from '@defra/forms-model'
 
 import { config } from '~/src/config/index.js'
@@ -6,6 +7,7 @@ import { createLogger } from '~/src/helpers/logging/logger.js'
 import { getFormDefinition } from '~/src/lib/manager.js'
 import { sendNotification } from '~/src/lib/notify.js'
 import { getFormatter } from '~/src/service/mappers/formatters/index.js'
+import { getUserConfirmationEmailBody } from '~/src/service/mappers/user-confirmation.js'
 
 // @ts-expect-error - incorrect typings in convict
 const templateId = /** @type {string} */ (config.get('notifyTemplateId'))
@@ -17,7 +19,18 @@ const logger = createLogger()
  * @param {FormAdapterSubmissionMessage} formSubmissionMessage
  * @returns {Promise<void>}
  */
-export async function sendNotifyEmail(formSubmissionMessage) {
+export async function sendNotifyEmails(formSubmissionMessage) {
+  // TODO - decide how to handle if first email throws
+  await sendInternalEmail(formSubmissionMessage)
+  await sendUserConfirmationEmail(formSubmissionMessage)
+}
+
+/**
+ * Sends an internal email to notify (to the form's submission inbox)
+ * @param {FormAdapterSubmissionMessage} formSubmissionMessage
+ * @returns {Promise<void>}
+ */
+export async function sendInternalEmail(formSubmissionMessage) {
   const {
     formName: formNameInput,
     formId,
@@ -29,10 +42,13 @@ export async function sendNotifyEmail(formSubmissionMessage) {
   const logTags = ['submit', 'email']
 
   // Get submission email personalisation
-  logger.info(logTags, 'Getting personalisation data')
+  logger.info(
+    logTags,
+    'Getting personalisation data - internal submission email'
+  )
 
   logger.debug(
-    `Getting form definition: ${formId} version: ${versionMetadata?.versionNumber}`
+    `Getting form definition: ${formId} version: ${versionMetadata?.versionNumber} - internal submission email`
   )
 
   const definition = await getFormDefinition(
@@ -58,7 +74,7 @@ export async function sendNotifyEmail(formSubmissionMessage) {
     body = Buffer.from(body).toString('base64')
   }
 
-  logger.info(logTags, 'Sending email')
+  logger.info(logTags, 'Sending internal submission email')
 
   try {
     // Send submission email
@@ -71,17 +87,76 @@ export async function sendNotifyEmail(formSubmissionMessage) {
       }
     })
 
-    logger.info(logTags, 'Email sent successfully')
+    logger.info(logTags, 'Internal submission email sent successfully')
   } catch (err) {
     const errMsg = getErrorMessage(err)
     logger.error(
       err,
-      `[emailSendFailed] Error sending notification email - templateId: ${templateId} - ${errMsg}`
+      `[emailSendFailed] Error sending internal submission email - templateId: ${templateId} - ${errMsg}`
     )
 
     throw err
   }
 }
+
+/**
+ * Sends a confirmation email to the submitting user
+ * @param {FormAdapterSubmissionMessage} formSubmissionMessage
+ * @returns {Promise<void>}
+ */
+export async function sendUserConfirmationEmail(formSubmissionMessage) {
+  if (!formSubmissionMessage.meta.userConfirmationEmail) {
+    return
+  }
+
+  const {
+    formId,
+    formName: formNameInput,
+    isPreview
+  } = formSubmissionMessage.meta
+  const logTags = ['submit', 'email']
+
+  // Get submission email personalisation
+  logger.info(logTags, 'Getting personalisation data - user confirmation email')
+
+  const formName = escapeMarkdown(formNameInput)
+  const emailAddress = formSubmissionMessage.meta.userConfirmationEmail
+
+  const metadata = await getFormMetadata(formId)
+
+  const subject = isPreview
+    ? `TEST FORM CONFIRMATION: ${metadata.organisation}`
+    : `Form submitted to ${metadata.organisation}`
+
+  logger.info(logTags, 'Sending user confirmation email')
+
+  if (!metadata.submissionGuidance) {
+    throw new Error(`Missing submission guidance for form id ${formId}`)
+  }
+
+  try {
+    // Send confirmation email
+    await sendNotification({
+      templateId,
+      emailAddress,
+      personalisation: {
+        subject,
+        body: getUserConfirmationEmailBody(formName, new Date(), metadata)
+      }
+    })
+
+    logger.info(logTags, 'User confirmation email sent successfully')
+  } catch (err) {
+    const errMsg = getErrorMessage(err)
+    logger.error(
+      err,
+      `[emailSendFailed] Error sending user confirmation email - templateId: ${templateId} - ${errMsg}`
+    )
+
+    throw err
+  }
+}
+
 /**
  * @import { FormAdapterSubmissionMessage } from '@defra/forms-engine-plugin/engine/types.js'
  */

--- a/src/service/notify.test.js
+++ b/src/service/notify.test.js
@@ -15,7 +15,7 @@ import {
   buildFormAdapterSubmissionMessageMetaStub,
   buildFormAdapterSubmissionMessageResult
 } from '~/src/service/__stubs__/event-builders.js'
-import { sendNotifyEmail } from '~/src/service/notify.js'
+import { sendNotifyEmails } from '~/src/service/notify.js'
 
 jest.mock('~/src/helpers/logging/logger.js', () => ({
   createLogger: () => ({
@@ -113,7 +113,7 @@ describe('notify', () => {
     lists: []
   })
 
-  describe('sendNotifyEmail', () => {
+  describe('sendNotifyEmails', () => {
     it('should send a v1 machine readable email', async () => {
       const definition = buildDefinition({
         ...baseDefinition,
@@ -123,7 +123,7 @@ describe('notify', () => {
         }
       })
       jest.mocked(getFormDefinition).mockResolvedValueOnce(definition)
-      await sendNotifyEmail(formAdapterSubmissionMessage)
+      await sendNotifyEmails(formAdapterSubmissionMessage)
 
       const [sendNotificationCall] = jest.mocked(sendNotification).mock.calls[0]
       expect(sendNotificationCall).toEqual({
@@ -155,7 +155,7 @@ describe('notify', () => {
 
     it('should send a v2 machine readable email', async () => {
       jest.mocked(getFormDefinition).mockResolvedValueOnce(baseDefinition)
-      await sendNotifyEmail(formAdapterSubmissionMessage)
+      await sendNotifyEmails(formAdapterSubmissionMessage)
 
       const [sendNotificationCall] = jest.mocked(sendNotification).mock.calls[0]
       expect(sendNotificationCall).toEqual({
@@ -627,7 +627,7 @@ describe('notify', () => {
       })
 
       jest.mocked(getFormDefinition).mockResolvedValueOnce(definition)
-      await sendNotifyEmail(formAdapterSubmissionMessage)
+      await sendNotifyEmails(formAdapterSubmissionMessage)
       expect(getFormDefinition).toHaveBeenCalledWith(
         formId,
         FormStatus.Live,
@@ -648,7 +648,7 @@ describe('notify', () => {
       jest.mocked(getFormDefinition).mockResolvedValueOnce(baseDefinition)
       jest.mocked(sendNotification).mockRejectedValueOnce(err)
       await expect(
-        sendNotifyEmail(formAdapterSubmissionMessage)
+        sendNotifyEmails(formAdapterSubmissionMessage)
       ).rejects.toThrow(err)
     })
 
@@ -677,7 +677,7 @@ describe('notify', () => {
         })
 
       jest.mocked(getFormDefinition).mockResolvedValueOnce(baseDefinition)
-      await sendNotifyEmail(versionedFormAdapterSubmissionMessage)
+      await sendNotifyEmails(versionedFormAdapterSubmissionMessage)
 
       expect(getFormDefinition).toHaveBeenCalledWith(
         formId,
@@ -688,7 +688,7 @@ describe('notify', () => {
 
     it('should use default form definition when versionMetadata is not present', async () => {
       jest.mocked(getFormDefinition).mockResolvedValueOnce(baseDefinition)
-      await sendNotifyEmail(formAdapterSubmissionMessage)
+      await sendNotifyEmails(formAdapterSubmissionMessage)
 
       expect(getFormDefinition).toHaveBeenCalledWith(
         formId,


### PR DESCRIPTION
Ticket [DF-330](https://eaflood.atlassian.net/browse/DF-330)

Processes submission message and sends user confirmation (if target email is supplied) in addition to the existing internal submission email