### PR TITLE
feat/df-983: Default to V2 internal email

### DIFF
--- a/src/service/notify.js
+++ b/src/service/notify.js
@@ -44,7 +44,7 @@ export async function sendNotifyEmails(formSubmissionMessage) {
     [
       {
         audience: definition.output?.audience ?? 'human',
-        version: definition.output?.version ?? '1',
+        version: definition.output?.version ?? '2',
         emailAddress
       }
     ].concat(definition.outputs ?? [])


### PR DESCRIPTION
Sets the internal submission email to use V2 human as the default (was previously defaulting to V1 human)