### PR TITLE
feat/df-1006: Handles message resubmission

### DIFF
--- a/src/messaging/event.js
+++ b/src/messaging/event.js
@@ -1,6 +1,7 @@
 import {
   DeleteMessageCommand,
   ReceiveMessageCommand,
+  SendMessageCommand,
   StartMessageMoveTaskCommand
 } from '@aws-sdk/client-sqs'
 
@@ -58,6 +59,39 @@ export function redriveDlqMessages() {
     SourceArn: deadLetterQueueArn
   })
   return sqsClient.send(command)
+}
+
+/**
+ * Submit the specified message to the main queue, and delete the messageId from the dead-letter queue
+ * @param {string} messageId
+ * @param {string} messageJson
+ */
+export async function resubmitDlqMessage(messageId, messageJson) {
+  try {
+    logger.info(
+      `[DLQ] Submitting new message in place of message id ${messageId}`
+    )
+
+    const command = new SendMessageCommand({
+      QueueUrl: queueUrl,
+      MessageBody: messageJson
+    })
+    const sendResult = await sqsClient.send(command)
+    logger.info(
+      `[DLQ] Submitting new message in place of message id ${messageId}. New message id is ${sendResult.MessageId}. About to delete old message from DLQ`
+    )
+
+    await deleteDlqMessage(messageId)
+    logger.info(
+      `[DLQ] Deleted message id ${messageId} from DLQ after resubmitting new message id ${sendResult.MessageId}`
+    )
+  } catch (err) {
+    logger.error(
+      err,
+      `[DLQ] Failed to submit new message to main queue or failed to delete old message of id ${messageId} from DLQ`
+    )
+    throw err
+  }
 }
 
 /**

--- a/src/messaging/event.test.js
+++ b/src/messaging/event.test.js
@@ -2,6 +2,7 @@ import {
   DeleteMessageCommand,
   ReceiveMessageCommand,
   SQSClient,
+  SendMessageCommand,
   StartMessageMoveTaskCommand
 } from '@aws-sdk/client-sqs'
 import { mockClient } from 'aws-sdk-client-mock'
@@ -12,7 +13,8 @@ import {
   deleteEventMessage,
   receiveDlqMessages,
   receiveEventMessages,
-  redriveDlqMessages
+  redriveDlqMessages,
+  resubmitDlqMessage
 } from '~/src/messaging/event.js'
 
 jest.mock('~/src/helpers/logging/logger.js')
@@ -120,6 +122,48 @@ describe('event', () => {
       snsMock.on(ReceiveMessageCommand).resolves(receivedMessage)
       await expect(() =>
         deleteDlqMessage(messageStub.MessageId)
+      ).rejects.toThrow(
+        'Message with id 31cb6fff-8317-412e-8488-308d099034c4 not found in notify-listener DLQ'
+      )
+    })
+  })
+
+  describe('resubmitDlqMessage', () => {
+    it('should resubmit message and delete old one from DLQ', async () => {
+      const receivedMessage = {
+        Messages: [messageStub]
+      }
+      snsMock.on(ReceiveMessageCommand).resolves(receivedMessage)
+
+      const sendMessage = {
+        MessageId: '12345'
+      }
+
+      snsMock.on(SendMessageCommand).resolves(sendMessage)
+      await resubmitDlqMessage(messageStub.MessageId, messageStub.Body)
+      expect(snsMock).toHaveReceivedCommandWith(SendMessageCommand, {
+        QueueUrl: expect.any(String),
+        MessageBody: messageStub.Body
+      })
+      expect(snsMock).toHaveReceivedCommandWith(DeleteMessageCommand, {
+        QueueUrl: expect.any(String),
+        ReceiptHandle: receiptHandle
+      })
+    })
+
+    it('should throw if message not found', async () => {
+      const receivedMessage = {
+        Messages: []
+      }
+      snsMock.on(ReceiveMessageCommand).resolves(receivedMessage)
+
+      const sendMessage = {
+        MessageId: '12345'
+      }
+      snsMock.on(SendMessageCommand).resolves(sendMessage)
+
+      await expect(() =>
+        resubmitDlqMessage(messageStub.MessageId, messageStub.Body)
       ).rejects.toThrow(
         'Message with id 31cb6fff-8317-412e-8488-308d099034c4 not found in notify-listener DLQ'
       )

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -5,7 +5,8 @@ import { createLogger } from '~/src/helpers/logging/logger.js'
 import {
   deleteDlqMessage,
   receiveDlqMessages,
-  redriveDlqMessages
+  redriveDlqMessages,
+  resubmitDlqMessage
 } from '~/src/messaging/event.js'
 
 const logger = createLogger()
@@ -44,6 +45,28 @@ export default [
       logger.info('Redriving DLQ')
       await redriveDlqMessages()
       logger.info('Redrive DLQ triggered successfully')
+      return h.response({ message: 'success' }).code(OK_RESPONSE)
+    },
+    options: {
+      auth: {
+        scope: [`+${Scopes.DeadLetterQueues}`]
+      }
+    }
+  }),
+
+  /**
+   * @satisfies {ServerRoute<{ Params: { messageId: string }, Payload: { messageJson: string } }>}
+   */
+  ({
+    method: 'POST',
+    path: '/admin/deadletter/resubmit/{messageId}',
+    async handler(request, h) {
+      const { params, payload } = request
+      const { messageId } = params
+      const { messageJson } = payload
+      logger.info(`Resubmitting DLQ message ${messageId}`)
+      await resubmitDlqMessage(messageId, JSON.stringify(messageJson))
+      logger.info(`Resubmitted  DLQ message ${messageId}`)
       return h.response({ message: 'success' }).code(OK_RESPONSE)
     },
     options: {

--- a/src/routes/admin.test.js
+++ b/src/routes/admin.test.js
@@ -2,7 +2,8 @@ import { createServer } from '~/src/api/server.js'
 import {
   deleteDlqMessage,
   receiveDlqMessages,
-  redriveDlqMessages
+  redriveDlqMessages,
+  resubmitDlqMessage
 } from '~/src/messaging/event.js'
 import { authSuperAdmin as auth } from '~/test/fixtures/auth.js'
 
@@ -54,6 +55,22 @@ describe('Admin routes', () => {
       expect(response.headers['content-type']).toContain(jsonContentType)
       expect(response.result).toEqual({ message: 'success' })
       expect(redriveDlqMessages).toHaveBeenCalled()
+    })
+
+    test('/admin/dead-letter/resubmit route returns 200', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/admin/deadletter/resubmit/12345',
+        auth,
+        payload: {
+          messageJson: {}
+        }
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toEqual({ message: 'success' })
+      expect(resubmitDlqMessage).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Handles message resubmission into main queue and deletion of original DLQ message
Ticket [DF-1006](https://eaflood.atlassian.net/browse/DF-1006)

[DF-1006]: https://eaflood.atlassian.net/browse/DF-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ